### PR TITLE
Improved list of installed scripts

### DIFF
--- a/tools/diagSinusbot.sh
+++ b/tools/diagSinusbot.sh
@@ -706,7 +706,7 @@ get_installed_bot_scripts()
 {
 	local INSTALLED_SCRIPTS=""
 	if [ -d "$BOT_PATH/scripts/" ]; then
-		for SCRIPT_FILE in $BOT_PATH/scripts/*; do
+		for SCRIPT_FILE in $BOT_PATH/scripts/*.js; do
 			if [ "$INSTALLED_SCRIPTS" == "" ]; then
 				local INSTALLED_SCRIPTS="$(basename "$SCRIPT_FILE")"
 			else


### PR DESCRIPTION
Improved installed scripts list so that only `.js` files will be shown instead of all. Because the installation via the store downloads meta data information in a `scriptname.js.store` file and saves them there.